### PR TITLE
feat: support configure meting.url into env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ docker run -d --name meting -p 3000:3000 intemd/meting-api:latest
 
 在浏览器中打开 http://localhost:3000/api 来进行测试 ✅
 
+在自己服务器部署时，可能需要通过 nginx 反代 nodejs，然后域名访问 `https://api.example.com/meting/api`
+```nginx
+server {
+    location /meting/ {
+        proxy_pass http://127.0.0.1:3000/;
+    }
+}
+```
+
+则需要添加环境变量
+
+```
+docker run -d --name meting -p 3000:3000 -e METING_URL="https://api.example.com/meting" intemd/meting-api:latest
+```
+
 ### 部署到vercel
 
 <a href="https://vercel.com/import/project?template=https://github.com/xizeyoupan/Meting-API"><img src="https://vercel.com/button" height="32"></a>

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -7,6 +7,7 @@ export default {
     prefix: process.env.HTTP_PREFIX || ''
   },
   meting: {
+    url: process.env.METING_URL || '',
     api: process.env.METING_API || '', // upstream php api
     token: process.env.METING_TOKEN || 'token'
   }

--- a/server/src/service/api.js
+++ b/server/src/service/api.js
@@ -105,9 +105,9 @@ export default async (ctx) => {
     return {
       title: x.name,
       author: x.artist.join(' / '),
-      url: `${origin}/api?server=${server}&type=url&id=${x.url_id}&auth=${auth(server, 'url', x.url_id)}`,
-      pic: `${origin}/api?server=${server}&type=pic&id=${x.pic_id}&auth=${auth(server, 'pic', x.pic_id)}`,
-      lrc: `${origin}/api?server=${server}&type=lrc&id=${x.lyric_id}&auth=${auth(server, 'lrc', x.lyric_id)}`
+      url: `${config.meting.url || origin}/api?server=${server}&type=url&id=${x.url_id}&auth=${auth(server, 'url', x.url_id)}`,
+      pic: `${config.meting.url || origin}/api?server=${server}&type=pic&id=${x.pic_id}&auth=${auth(server, 'pic', x.pic_id)}`,
+      lrc: `${config.meting.url || origin}/api?server=${server}&type=lrc&id=${x.lyric_id}&auth=${auth(server, 'lrc', x.lyric_id)}`
     }
   })
 }


### PR DESCRIPTION
使用当前镜像部署到自己的服务器，通过 nginx 反代
```nginx
server {
    location /meting/ {
        proxy_pass http://127.0.0.1:3000/;
    }
}
```

会导致下图 url 错误

![image](https://user-images.githubusercontent.com/44741777/215278044-da996fa7-4c07-443b-af7b-a70d1d862043.png)

稍微修改了一下，添加个可选环境变量
```
docker run -d --name meting -p 3000:3000 -e METING_URL="https://api.example.com/meting"
```
